### PR TITLE
Bugfix: Breaking Navigation Bar Tint Color

### DIFF
--- a/UIViewController+BackButtonHandler.m
+++ b/UIViewController+BackButtonHandler.m
@@ -50,7 +50,7 @@
 	} else {
 		// Workaround for iOS7.1. Thanks to @boliva - http://stackoverflow.com/posts/comments/34452906
 		for(UIView *subview in [navigationBar subviews]) {
-			if(subview.alpha < 1.) {
+			if(0. < subview.alpha && subview.alpha < 1.) {
 				[UIView animateWithDuration:.25 animations:^{
 					subview.alpha = 1.;
 				}];


### PR DESCRIPTION
The process restoring alpha values breaks tint color of a navigation bar.
Tint color of a navigation bar is a sort of this:
```swift
UINavigationBar.appearance().tintColor = UIColor.redColor()
```

I got disappearance of button title and view title when I canceled back button.

![b967f3e0-ed36-11e4-89f0-b40635742f3e](https://cloud.githubusercontent.com/assets/2055516/7669590/65bfb248-fcb6-11e4-82b7-5a55dfb139c7.png)

iPhone 5S; iOS 8.3

---

Ignoring zero alpha elements fix the problem.

![f85f546a-ed38-11e4-8923-d2bfc89aec66](https://cloud.githubusercontent.com/assets/2055516/7669591/6c0d5556-fcb6-11e4-9e1f-3097f698ec16.png)


Thanks.