### PR TITLE
Handle interactive pop gesture recognizer

### DIFF
--- a/UIViewController+BackButtonHandler.m
+++ b/UIViewController+BackButtonHandler.m
@@ -44,9 +44,11 @@
 	}
 
 	if(shouldPop) {
-		dispatch_async(dispatch_get_main_queue(), ^{
-			[self popViewControllerAnimated:YES];
-		});
+		if(self.interactivePopGestureRecognizer.state != UIGestureRecognizerStateBegan) {
+			dispatch_async(dispatch_get_main_queue(), ^{
+				[self popViewControllerAnimated:YES];
+			});
+		}
 	} else {
 		// Workaround for iOS7.1. Thanks to @boliva - http://stackoverflow.com/posts/comments/34452906
 		for(UIView *subview in [navigationBar subviews]) {


### PR DESCRIPTION
Interactive pop gesture recognizer calls the same navigation bar delegate methods at the point when interactive transition starts. At this point `interactivePopGestureRecognizer.state` is `.Began` so we can simply filter out that edge case and avoid popping controller. Interactive pop gesture will handle the navigation stack at the end of transition.